### PR TITLE
feat(layout): add page footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { Metadata } from 'next';
 import { fontMono, fontSans } from '@/lib/font';
 import { PageHeader } from '@/components/page-header';
+import { PageFooter } from '@/components/page-footer';
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -21,6 +22,7 @@ export default function RootLayout({
         <div className="relative grid min-h-screen-dvh grid-rows-[var(--header-height)_1fr] bg-background">
           <PageHeader />
           {children}
+          <PageFooter />
         </div>
       </body>
     </html>

--- a/components/light-dark-theme-switcher.tsx
+++ b/components/light-dark-theme-switcher.tsx
@@ -1,0 +1,52 @@
+import { Icon } from './ui/icon';
+import { Label } from './ui/label';
+import { RadioGroup, RadioGroupItem } from './ui/radio-group';
+
+export function LightDarkThemeSwitcher(): JSX.Element {
+  return (
+    <RadioGroup
+      defaultValue="system"
+      className="flex flex-row items-center justify-center gap-0 rounded-full border p-0.5 focus-within:ring-1 focus-within:ring-ring"
+    >
+      <div>
+        <RadioGroupItem
+          id="light-theme-radio-switch"
+          value="light"
+          className="peer sr-only"
+        />
+        <Label
+          htmlFor="light-theme-radio-switch"
+          className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-accent hover:text-accent-foreground peer-aria-checked:bg-primary peer-aria-checked:text-primary-foreground"
+        >
+          <Icon.Lucide name="sun" className="h-4 w-4" />
+        </Label>
+      </div>
+      <div>
+        <RadioGroupItem
+          id="system-theme-radio-switch"
+          value="system"
+          className="peer sr-only"
+        />
+        <Label
+          htmlFor="system-theme-radio-switch"
+          className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-accent hover:text-accent-foreground peer-aria-checked:bg-primary peer-aria-checked:text-primary-foreground"
+        >
+          <Icon.Lucide name="monitor" className="h-4 w-4" />
+        </Label>
+      </div>
+      <div>
+        <RadioGroupItem
+          id="dark-theme-radio-switch"
+          value="dark"
+          className="peer sr-only"
+        />
+        <Label
+          htmlFor="dark-theme-radio-switch"
+          className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-accent hover:text-accent-foreground peer-aria-checked:bg-primary peer-aria-checked:text-primary-foreground"
+        >
+          <Icon.Lucide name="moon" className="h-4 w-4" />
+        </Label>
+      </div>
+    </RadioGroup>
+  );
+}

--- a/components/page-footer.tsx
+++ b/components/page-footer.tsx
@@ -20,7 +20,7 @@ export function PageFooter({
       )}
       {...props}
     >
-      <div className="mx-auto grid w-full max-w-2xl grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-8 px-4 md:max-w-3xl md:px-8 lg:max-w-5xl lg:grid-cols-6 xl:max-w-7xl">
+      <div className="mx-auto grid w-full max-w-2xl grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-x-8 gap-y-10 px-4 md:max-w-3xl md:px-8 lg:max-w-5xl lg:grid-cols-6 xl:max-w-7xl">
         <div className="col-span-full flex w-full flex-row items-center justify-between gap-4 lg:col-span-2 lg:flex-col lg:items-start lg:justify-start">
           <Button
             variant="link"

--- a/components/page-footer.tsx
+++ b/components/page-footer.tsx
@@ -1,0 +1,122 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { Button } from './ui/button';
+import { Icon } from './ui/icon';
+import { Input } from './ui/input';
+import { LightDarkThemeSwitcher } from './light-dark-theme-switcher';
+
+type PageFooterProps = React.HTMLAttributes<HTMLElement>;
+
+export function PageFooter({
+  className,
+  ...props
+}: PageFooterProps): JSX.Element {
+  return (
+    <footer
+      className={cn(
+        'relative isolate grid grid-cols-1 gap-[calc(var(--y-padding)*2)] border-t py-8',
+        '[--y-padding:theme(spacing.6)] md:[--y-padding:theme(spacing.10)] lg:[--y-padding:theme(spacing.12)]',
+        className,
+      )}
+      {...props}
+    >
+      <div className="mx-auto grid w-full max-w-2xl grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-8 px-4 md:max-w-3xl md:px-8 lg:max-w-5xl lg:grid-cols-6 xl:max-w-7xl">
+        <div className="col-span-full flex w-full flex-row items-center justify-between gap-4 lg:col-span-2 lg:flex-col lg:items-start lg:justify-start">
+          <Button
+            variant="link"
+            className="px-1 text-xl font-semibold hover:no-underline lg:-mt-2"
+            asChild
+          >
+            <Link href="/">_triskacode</Link>
+          </Button>
+          <div className="flex items-center justify-start gap-2">
+            <Button variant="outline" size="icon" asChild>
+              <Link href="https://github.com/triskacode" target="_blank">
+                <Icon.GitHub className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <h4 className="text-sm font-semibold">Resources</h4>
+          <ul className="flex flex-col gap-2 text-sm">
+            <li>
+              <Link href="/">Home</Link>
+            </li>
+            <li>
+              <Link href="/project">Project</Link>
+            </li>
+            <li>
+              <Link href="/blog">Blog</Link>
+            </li>
+          </ul>
+        </div>
+        <div className="flex flex-col gap-4">
+          <h4 className="text-sm font-semibold">More</h4>
+          <ul className="flex flex-col gap-2 text-sm">
+            <li>
+              <Link href="/about">About Triskacode</Link>
+            </li>
+            <li>
+              <Link href="/contact">Contact</Link>
+            </li>
+            <li>
+              <Link href="https://github.com/triskacode" target="_blank">
+                Github
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="col-span-full flex w-full max-w-sm flex-col gap-4 md:col-span-2">
+          <h4 className="text-sm font-semibold">Subscribe to our newsletter</h4>
+          <div className="flex flex-col items-start justify-start gap-2">
+            <div className="text-start text-sm">
+              <p>
+                Subscribe to our newsletter to receive updates about our latest
+                projects and events.
+              </p>
+            </div>
+            <form className="relative flex w-full flex-row items-center">
+              <Input
+                type="email"
+                placeholder="email@example.com"
+                className="h-10 pr-24"
+              />
+              <Button
+                variant="secondary"
+                size="sm"
+                className="absolute right-1"
+              >
+                Subscribe
+              </Button>
+            </form>
+          </div>
+        </div>
+      </div>
+      <div className="mx-auto grid w-full max-w-2xl grid-cols-2 justify-items-stretch gap-8 px-4 md:max-w-3xl md:px-8 lg:max-w-5xl xl:max-w-7xl">
+        <div className="flex items-center text-start text-sm">
+          <p>&copy; 2023 Triskacode. All rights reserved.</p>
+        </div>
+        <div className="justify-self-end">
+          <LightDarkThemeSwitcher />
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+/**
+ "Hi AI, I need assistance in filling out the content layout for my personal portfolio blog landing page that is already set up in the code editor. Please help me by providing text for each of the following sections. Ensure that the text is engaging, unique, optimized for SEO, and appropriate for the context below:
+
+- Footer Section:
+  - Purpose: Provide a nice and engaging footer section for the blog landing page. including the relevant primary keyword (if applicable).
+  - Details: Write a title and link text that will be displayed in the footer section of the blog landing page.
+
+SEO Notes:
+  - This is my primary keyword "Fullstack Developer" and my secondary keyword "Fullstack Developer Case Study Experience".
+  - Ensure to include the primary and secondary keywords naturally in each section.
+  - Use variations of keywords and related phrases to enhance search relevance.
+  - Include internal linking if there are other relevant pages on your site connected to the displayed content.
+
+Thank you for helping to make my landing page content informative, engaging, and SEO-friendly!" 
+ */

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import * as React from 'react';
+import { CheckIcon } from '@radix-ui/react-icons';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { cn } from '@/lib/utils';
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn('grid gap-2', className)}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        'aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <CheckIcon className="h-3.5 w-3.5 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-radio-group": "^1.2.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@radix-ui/react-icons':
         specifier: ^1.3.0
         version: 1.3.0(react@18.3.1)
+      '@radix-ui/react-label':
+        specifier: ^2.1.0
+        version: 2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.2.0
+        version: 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.3)(react@18.3.1)
@@ -402,6 +408,19 @@ packages:
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
 
+  '@radix-ui/react-collection@1.1.0':
+    resolution: {integrity: sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
@@ -431,6 +450,15 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.0':
+    resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.0':
@@ -482,6 +510,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.0':
+    resolution: {integrity: sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.1':
     resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
     peerDependencies:
@@ -510,6 +551,32 @@ packages:
 
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.2.0':
+    resolution: {integrity: sha512-yv+oiLaicYMBpqgfpSPw6q+RyXlLdIpQWDHZbUKURxe+nEh53hFXPPlfhfQQtYkS5MMK/5IWIa76SksleQZSzw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.0':
+    resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -559,6 +626,24 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.0':
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.0':
+    resolution: {integrity: sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.0':
+    resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3263,6 +3348,18 @@ snapshots:
 
   '@radix-ui/primitive@1.1.0': {}
 
+  '@radix-ui/react-collection@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-compose-refs@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -3296,6 +3393,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-direction@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   '@radix-ui/react-dismissable-layer@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -3338,6 +3441,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  '@radix-ui/react-label@2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-portal@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3361,6 +3473,41 @@ snapshots:
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-radio-group@1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-roving-focus@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -3396,6 +3543,19 @@ snapshots:
 
   '@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-previous@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-size@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3


### PR DESCRIPTION
* **feat(layout): add page footer component**
This commit introduces the PageFooter component, enhancing the overall layout structure. The PageFooter includes navigation links and a newsletter signup feature, improving user engagement. Additionally, a LightDarkThemeSwitcher component has been implemented to allow users to select their preferred theme. The PageFooter has been integrated into the RootLayout for consistent application-wide use. New UI components, Label and RadioGroup, have been added to expand the available design elements. Finally, dependencies have been updated to incorporate the latest Radix UI packages, ensuring access to modern UI capabilities.

* **fix(layout): adjust grid gap for improved layout**
This commit modifies the grid gap in the PageFooter component, replacing the uniform gap-8 with separate gap-x-8 and gap-y-10 settings. The change enhances the vertical spacing between footer elements, resulting in an improved layout and visual hierarchy. This adjustment contributes to a more balanced and aesthetically pleasing footer design, enhancing the overall user experience.
