### PR TITLE
fix(layout): improve mobile menu navigation

### DIFF
--- a/components/nav-menu.tsx
+++ b/components/nav-menu.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Button, type ButtonProps } from './ui/button';
 import {
@@ -16,12 +16,12 @@ import { ScreenReaderOnly } from './ui/screen-reader-only';
 
 const links = [
   {
-    label: 'Blog',
-    href: '/blog',
-  },
-  {
     label: 'Project',
     href: '/project',
+  },
+  {
+    label: 'Blog',
+    href: '/blog',
   },
 ];
 
@@ -34,18 +34,16 @@ export function NavMenu({ className }: NavMenuProps): JSX.Element {
 
   return (
     <nav
-      className={cn(
-        'flex items-center space-x-4 text-sm lg:space-x-6',
-        className,
-      )}
+      className={cn('flex items-center gap-x-4 text-sm lg:gap-x-6', className)}
     >
       {links.map((link) => (
         <Button
           key={link.href}
           asChild
+          size="sm"
           variant="link"
           className={cn(
-            'px-0 font-normal text-foreground/60 transition-colors hover:text-foreground/80',
+            'px-1 font-normal text-foreground/60 transition-colors hover:text-foreground/80',
             { 'text-foreground': pathname === link.href },
           )}
         >
@@ -62,7 +60,12 @@ export function MobileMenu({
   className,
   ...props
 }: MobileMenuProps): JSX.Element {
+  const pathname = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [pathname]);
 
   return (
     <Sheet open={isMenuOpen} onOpenChange={setIsMenuOpen}>
@@ -96,27 +99,29 @@ export function MobileMenu({
         </Button>
       </SheetTrigger>
       <SheetContent
-        className="top-[var(--header-height)] h-[calc(100dvh-var(--header-height))] w-[min(85vw,360px)] p-0 focus-visible:outline-none sm:w-[540px]"
+        className="top-[var(--header-height)] h-[calc(100dvh-var(--header-height))] w-[min(85vw,360px)] border-none p-0 focus-visible:outline-none sm:w-[540px]"
         overlayClassName="top-[calc(var(--header-height))] h-[calc(100dvh-var(--header-height))]"
       >
         <ScreenReaderOnly>
-          <SheetTitle>Navigation Menu</SheetTitle>
-          <SheetDescription>Main site navigation options</SheetDescription>
+          <SheetTitle>Portfolio Navigation</SheetTitle>
+          <SheetDescription>
+            Explore the portfolio of a Fullstack Developer
+          </SheetDescription>
         </ScreenReaderOnly>
-        <div className="scroller grid h-full grid-flow-row auto-rows-max content-between gap-y-6 overflow-y-auto p-6">
+        <div className="scroller grid h-full grid-flow-row auto-rows-max content-between gap-y-4 overflow-y-auto p-4">
           <NavMenu
             className={cn(
-              '-mx-6 flex-none flex-col items-stretch space-x-0 space-y-2',
-              '[&>a]:justify-start [&>a]:px-6 [&>a]:text-base',
+              '-mx-4 flex-none flex-col items-stretch gap-x-0 gap-y-2',
+              '[&>a]:justify-start [&>a]:px-4 [&>a]:text-base',
             )}
           />
-          <div className="-mx-3 mt-auto rounded-md border px-3 py-2">
+          <div className="mt-auto flex flex-col items-start justify-center gap-2 rounded-md border p-2">
             <Button asChild className="w-full text-sm">
               <Link href="/login">Login</Link>
             </Button>
-            <p className="mt-2 text-xs text-muted-foreground">
-              Login to comment on blog posts, and stay updated on my latest work
-              and join the discussion!
+            <p className="text-xs text-muted-foreground">
+              Access your account to view exclusive Fullstack Developer case
+              studies and project insights.
             </p>
           </div>
         </div>

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -15,18 +15,19 @@ export function PageHeader({ className }: PageHeaderProps): JSX.Element {
         className,
       )}
     >
-      <div className="container grid h-[var(--header-height)] max-w-screen-2xl auto-cols-max grid-flow-col items-center justify-between">
-        <div className="flex space-x-6 lg:space-x-9">
+      <div className="mx-auto grid h-[var(--header-height)] max-w-screen-2xl auto-cols-max grid-flow-col items-center justify-between px-4 md:px-8">
+        <div className="flex gap-6 lg:gap-10">
           <Button
+            size="sm"
             variant="link"
-            className="px-0 text-xl font-semibold hover:no-underline"
+            className="px-1 text-xl font-semibold hover:no-underline"
             asChild
           >
             <Link href="/">_triskacode</Link>
           </Button>
           <NavMenu className="hidden md:flex" />
         </div>
-        <div className="flex space-x-2 lg:space-x-4">
+        <div className="flex gap-2 lg:gap-4">
           <Button
             variant="ghost"
             size="sm"
@@ -45,7 +46,7 @@ export function PageHeader({ className }: PageHeaderProps): JSX.Element {
             </kbd>
           </Button>
           <MobileMenu className="md:hidden" />
-          <Button asChild size="sm" className="hidden text-sm md:flex">
+          <Button asChild size="sm" className="hidden md:flex">
             <Link href="/login">Login</Link>
           </Button>
         </div>


### PR DESCRIPTION
* **fix(layout): improve mobile menu navigation**
This commit focuses on improving the mobile menu navigation for better user experience. The navigation links have been reordered, placing the Project link before the Blog link. The mobile menu now automatically closes upon navigation, enhancing usability. Styling adjustments have been made to improve spacing and alignment throughout the menu. The login section content in the mobile menu has been updated for clarity. Accessibility has been improved by adding more descriptive screen reader text. Finally, the header layout and button styling have been refined for a more polished appearance. These changes collectively contribute to a more intuitive and visually appealing mobile navigation experience.
