### PR TITLE
chore(commitlint): update allowed commit types

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -5,18 +5,14 @@ module.exports = {
       2,
       'always',
       [
-        'build',
-        'chore',
+        // Changes to our CI configuration files and scripts
         'ci',
-        'docs',
+        // A new feature
         'feat',
+        // A bug fix
         'fix',
-        'perf',
+        // A code change that neither fixes a bug nor adds a feature
         'refactor',
-        'revert',
-        'style',
-        'test',
-        'release',
       ],
     ],
     'type-case': [2, 'always', 'lower-case'],


### PR DESCRIPTION
* **chore(commitlint): update allowed commit types**
This change simplifies the commit process by reducing the list of allowed commit types to ci, feat, fix, and refactor. Less frequently used types have been removed to streamline the workflow. The type-enum rule in .commitlintrc.js has been updated to reflect these changes, making it easier for developers to choose appropriate commit types and maintain a consistent commit history.
