### PR TITLE
feat(blog): add blur effect to images in mdx content

### DIFF
--- a/components/mdx-content.tsx
+++ b/components/mdx-content.tsx
@@ -1,5 +1,5 @@
 import * as runtime from 'react/jsx-runtime';
-import Image from 'next/image';
+import Image, { type ImageProps } from 'next/image';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { Callout } from './callout';
@@ -69,7 +69,7 @@ const sharedComponents = {
   td: Td,
   pre: Pre,
   code: Code,
-  Image,
+  Image: StyledImage,
   Callout,
 };
 
@@ -280,6 +280,15 @@ function Code({
         'relative rounded border px-[0.3rem] py-[0.2rem] font-mono text-sm',
         className,
       )}
+      {...props}
+    />
+  );
+}
+
+function StyledImage(props: ImageProps): React.JSX.Element {
+  return (
+    <Image
+      className="rounded-md border bg-muted transition-colors"
       {...props}
     />
   );

--- a/lib/remark/remark-blur-next-image.ts
+++ b/lib/remark/remark-blur-next-image.ts
@@ -1,0 +1,107 @@
+import { basename } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { assets, getImageMetadata, type Output as VeliteOutput } from 'velite';
+import type { Root } from 'mdast';
+import type { MdxJsxAttribute, MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
+import { visit } from 'unist-util-visit';
+import { isAbsoluteUrl } from '../utils';
+
+type BlurNextImageOptions = Pick<VeliteOutput, 'base' | 'assets'>;
+const emptyOptions: BlurNextImageOptions = {
+  base: '/static/',
+  assets: 'public/static',
+};
+
+export function remarkBlurNextImage(options?: BlurNextImageOptions) {
+  const settings = { ...emptyOptions, ...(options ?? {}) };
+
+  function isVeliteAsset(path: string): boolean {
+    return path.startsWith(settings.base);
+  }
+
+  function isBlurable(node: MdxJsxFlowElement): boolean {
+    return (
+      node.name === 'Image' &&
+      (node.attributes as MdxJsxAttribute[]).some(
+        (attr) =>
+          attr.name === 'src' &&
+          (isAbsoluteUrl(String(attr.value)) ||
+            isVeliteAsset(String(attr.value))),
+      )
+    );
+  }
+
+  return async (tree: Root) => {
+    const imageNodes = new Map<string, MdxJsxFlowElement[]>();
+
+    visit(tree, 'mdxJsxFlowElement', (node: MdxJsxFlowElement) => {
+      if (isBlurable(node)) {
+        const src = (node.attributes as MdxJsxAttribute[]).find(
+          (attr) => attr.name === 'src',
+        )?.value as string;
+        const imageNode = imageNodes.get(src) ?? [];
+
+        imageNode.push(node);
+        imageNodes.set(src, imageNode);
+      }
+    });
+
+    await Promise.all(
+      Array.from(imageNodes.entries()).map(async ([src, _nodes]) => {
+        let buffer = Buffer.from('');
+
+        if (isVeliteAsset(src)) {
+          // e.g foo.png?foo=bar#baz
+          const queryIdx = src.indexOf('?');
+          const hashIdx = src.indexOf('#');
+          const index = Math.min(
+            queryIdx > 0 ? queryIdx : Infinity,
+            hashIdx > 0 ? hashIdx : Infinity,
+          );
+          const path = index > 0 ? src.slice(0, index) : src;
+
+          const filePath = assets.get(basename(path));
+          if (!filePath) return Promise.resolve();
+
+          buffer = await readFile(filePath);
+        }
+
+        if (isAbsoluteUrl(src)) {
+          const response = await fetch(src);
+          const arrBuffer = await response.arrayBuffer();
+
+          buffer = Buffer.from(arrBuffer);
+        }
+
+        if (buffer.length === 0) return Promise.resolve();
+
+        const metadata = await getImageMetadata(buffer);
+        if (!metadata) return Promise.resolve();
+
+        const attributes = {
+          blurDataURL: metadata.blurDataURL,
+          placeholder: 'blur',
+        };
+
+        _nodes.forEach((node) => {
+          Object.entries(attributes).forEach(([key, value]) => {
+            const nodeAttributes = node.attributes as MdxJsxAttribute[];
+            const attr = nodeAttributes.find((_attr) => _attr.name === key);
+
+            if (attr) {
+              attr.value = value;
+            } else {
+              nodeAttributes.push({
+                type: 'mdxJsxAttribute',
+                name: key,
+                value,
+              });
+            }
+          });
+        });
+
+        return Promise.resolve();
+      }),
+    );
+  };
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -27,3 +27,9 @@ export function formatTime(minutes: number): string {
   }
   return `${hours.toString()} hour${hours > 1 ? 's' : ''} ${remainingMinutes.toString()} min`;
 }
+
+/** @see https://github.com/sindresorhus/is-absolute-url/blob/main/index.js */
+export function isAbsoluteUrl(url: string): boolean {
+  const absoluteUrlRegex = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/;
+  return absoluteUrlRegex.test(url);
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -66,6 +67,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "husky": "^9.1.2",
     "lint-staged": "^15.2.7",
+    "mdast-util-mdx-jsx": "^3.1.2",
     "npm-run-all": "^4.1.5",
     "postcss": "^8",
     "prettier": "^3.3.3",
@@ -74,6 +76,7 @@
     "rehype-slug": "^6.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
+    "unist-util-visit": "^5.0.0",
     "velite": "^0.1.1"
   },
   "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.2.2
         version: 19.2.2
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^20
         version: 20.14.12
@@ -93,6 +96,9 @@ importers:
       lint-staged:
         specifier: ^15.2.7
         version: 15.2.7
+      mdast-util-mdx-jsx:
+        specifier: ^3.1.2
+        version: 3.1.2
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -117,6 +123,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.5.4
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       velite:
         specifier: ^0.1.1
         version: 0.1.1

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -1,6 +1,7 @@
 import rehypeSlug from 'rehype-slug';
 import { rehypePrettyCode } from 'rehype-pretty-code';
 import { defineCollection, defineConfig, defineSchema, s } from 'velite';
+import { remarkBlurNextImage } from './lib/remark/remark-blur-next-image';
 
 const withSlugParams = <T extends { slug: string }>(
   data: T,
@@ -86,6 +87,7 @@ export default defineConfig({
   },
   collections: { about, posts },
   mdx: {
+    remarkPlugins: [[remarkBlurNextImage]],
     rehypePlugins: [rehypeSlug, [rehypePrettyCode, { theme: 'github-dark' }]],
   },
 });


### PR DESCRIPTION
* **feat(blog): add blur effect to images in mdx content**
This commit introduces a blur effect for images in MDX content, enhancing the visual appeal of the blog. A custom Image component has been implemented, featuring rounded corners and a border for a polished look. To automate the process, a new remark plugin has been created to generate blur data for images. Utility functions have been updated to support absolute URL detection, ensuring compatibility with various image sources. The Velite configuration has been adjusted to incorporate the new remark plugin, streamlining the image processing workflow. These changes collectively improve the overall user experience and aesthetics of the blog's image display.
