### PR TITLE
feat(home): update layout to remove newsletter section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
+import Link from 'next/link';
 import { PostCard } from '@/components/post-card';
 import { ProjectCard } from '@/components/project-card';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
-import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { posts, projects } from '#site/content';
 
@@ -103,46 +103,32 @@ export default function Home(): JSX.Element {
           ))}
         </div>
       </section>
-      {/* subscribe newsletter and contact section */}
+      {/* contact section */}
       <section
         className={cn(
-          'mx-auto grid w-full max-w-2xl grid-cols-1 gap-[calc(var(--y-padding)*2)] px-4 py-[calc(72px-var(--y-padding))] md:max-w-3xl md:px-8 md:py-[calc(140px-var(--y-padding))] lg:max-w-5xl lg:grid-cols-3 lg:gap-6 xl:max-w-7xl',
+          'mx-auto grid w-full max-w-2xl grid-cols-1 gap-[calc(var(--y-padding)*2)] px-4 py-[calc(72px-var(--y-padding))] md:max-w-3xl md:px-8 md:py-[calc(140px-var(--y-padding))] lg:max-w-5xl xl:max-w-7xl',
           '[--y-padding:theme(spacing.6)] md:[--y-padding:theme(spacing.10)] lg:[--y-padding:theme(spacing.12)]',
         )}
       >
-        {/* subscribe newsletter */}
-        <div className="flex max-w-2xl flex-col items-center justify-between gap-6 justify-self-center py-[var(--y-padding)] lg:col-span-2 lg:items-start lg:justify-self-start">
-          {/* subscribe newsletter intro  */}
-          <div className="text-balance text-center text-xl tracking-tight lg:text-start lg:text-2xl">
+        <div className="flex max-w-3xl flex-col items-center justify-center gap-4 justify-self-center md:gap-6 lg:gap-8">
+          {/* intro */}
+          <div className="flex flex-col items-center justify-center">
+            <h1 className="text-balance text-center text-4xl/none font-bold tracking-tight md:text-5xl lg:text-6xl">
+              What&apos;s next?
+            </h1>
+          </div>
+          {/* brief description */}
+          <div className="text-center text-base md:text-lg">
             <p>
-              <b className="text-foreground">Elevate your fullstack skills.</b>{' '}
-              Get exclusive insights, case studies, and development tips
-              straight to your inbox.
+              Let&apos;s collaborate on your next fullstack project. Reach out
+              for consultations or case study discussions.
             </p>
           </div>
-          {/* subscribe newsletter form */}
-          <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3">
-            <form className="flex w-full max-w-sm items-center space-x-2">
-              <Input type="email" placeholder="email@example.com" />
-              <Button type="submit">Subscribe</Button>
-            </form>
-          </div>
-        </div>
-        {/* contact section */}
-        <div className="flex items-center justify-center lg:py-[calc(var(--y-padding)/2)]">
-          <div className="flex h-full max-w-2xl flex-col items-center justify-between gap-6 justify-self-center rounded-md border p-[var(--y-padding)] lg:col-span-2 lg:items-start lg:justify-self-start lg:p-[calc(var(--y-padding)/2)]">
-            {/* contact section intro  */}
-            <div className="text-balance text-center text-base lg:text-start">
-              <p>
-                <b className="text-foreground">Let&apos;s collaborate</b> on
-                your next fullstack project. Reach out for consultations or case
-                study discussions.
-              </p>
-            </div>
-            {/* contact cta */}
-            <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3">
-              <Button>Get started</Button>
-            </div>
+          {/* contact cta */}
+          <div className="flex flex-wrap items-center justify-center gap-4 md:gap-x-6">
+            <Button asChild variant="default" size="lg">
+              <Link href="/contact">Get started</Link>
+            </Button>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Closes #52 

* **feat(home): update layout to remove newsletter section**
This change removes the newsletter section from the home page layout and modifies the contact section to center its content. These updates improve the overall layout and focus of the home page, providing a cleaner and more streamlined user experience.
