### PR TITLE
fix(components): remove hover effect from post card title

### DIFF
--- a/components/post-card.tsx
+++ b/components/post-card.tsx
@@ -50,11 +50,7 @@ export function PostCard({
           </dl>
           <dt className="sr-only">Title</dt>
           <dd className="line-clamp-2 w-full text-xl font-semibold tracking-tight md:text-2xl">
-            <Link
-              href={post.slug}
-              className="hover:text-blue-500"
-              aria-label={post.title}
-            >
+            <Link href={post.slug} aria-label={post.title}>
               {post.title}
             </Link>
           </dd>


### PR DESCRIPTION
Closes #44 

* **fix(components): remove hover effect from post card title**
The hover effect on the post card title was causing issues with the color contrast ratio. Removing this effect improves accessibility and ensures better readability for all users. This change maintains the visual consistency of the post cards while addressing the contrast concerns.
