### PR TITLE
feat(blog): add table of content to blog posts

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -3,10 +3,11 @@ import { notFound } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { posts, type Post } from '#site/content';
-import { formatDate, formatTime } from '@/lib/utils';
+import { cn, formatDate, formatTime } from '@/lib/utils';
 import { MDXContent } from '@/components/mdx-content';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
+import { PostTableOfContent } from '@/components/toc';
 import { ScrollToTopButton, ShareButton } from './button';
 
 function getPostFromParams(params: { slug?: string[] }): Post | undefined {
@@ -37,59 +38,71 @@ export default function Page({ params }: PageProps): React.JSX.Element {
 
   return (
     <main className="relative isolate bg-background pb-4 text-foreground md:pb-8 lg:pb-24">
-      <section className="mx-auto grid w-full max-w-3xl grid-cols-1 gap-6 px-4 py-6 md:gap-8 md:px-8 md:py-8 lg:py-10">
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <h1 className="text-balance text-start text-4xl/none font-bold tracking-tight md:text-5xl">
-              {post.title}
-            </h1>
+      <section className="mx-auto grid w-full max-w-6xl grid-cols-1 gap-6 px-4 py-6 md:gap-8 md:px-8 md:py-8 lg:grid-cols-[1fr_300px] lg:gap-10 lg:py-10 xl:gap-20">
+        <div className="mx-auto grid max-w-3xl grid-cols-1 gap-6 md:gap-8">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <h1 className="text-balance text-start text-4xl/none font-bold tracking-tight md:text-5xl">
+                {post.title}
+              </h1>
+            </div>
+            <div className="text-start text-base md:text-lg">
+              <p>{post.description}</p>
+            </div>
+            <div className="flex flex-row flex-wrap gap-2 text-sm">
+              <time
+                dateTime={post.updated ?? post.date}
+                className="text-muted-foreground"
+              >
+                {formatDate(post.updated ?? post.date)}
+                {post.updated ? ' (Updated)' : ''}
+              </time>
+              <span className="text-muted-foreground odd:hidden">·</span>
+              <span className="text-muted-foreground">
+                {formatTime(post.info.readingTime)} read
+              </span>
+              <span className="text-muted-foreground odd:hidden">·</span>
+              <span className="text-muted-foreground">
+                {post.info.wordCount} words
+              </span>
+            </div>
           </div>
-          <div className="text-start text-base md:text-lg">
-            <p>{post.description}</p>
-          </div>
-          <div className="flex flex-row flex-wrap gap-2 text-sm">
-            <time
-              dateTime={post.updated ?? post.date}
-              className="text-muted-foreground"
-            >
-              {formatDate(post.updated ?? post.date)}
-              {post.updated ? ' (Updated)' : ''}
-            </time>
-            <span className="text-muted-foreground odd:hidden">·</span>
-            <span className="text-muted-foreground">
-              {formatTime(post.info.readingTime)} read
-            </span>
-            <span className="text-muted-foreground odd:hidden">·</span>
-            <span className="text-muted-foreground">
-              {post.info.wordCount} words as
-            </span>
+          <Image
+            src={post.cover.src}
+            width={post.cover.width}
+            height={post.cover.height}
+            placeholder="blur"
+            blurDataURL={post.cover.blurDataURL}
+            className="rounded-md border bg-muted transition-colors"
+            alt={`Cover image for ${post.title}`}
+          />
+          <article>
+            <MDXContent code={post.body} />
+          </article>
+          <hr />
+          <div className="flex flex-row items-center justify-between gap-4">
+            <div>
+              <Button variant="outline" asChild>
+                <Link href="/blog">
+                  <Icon.Lucide name="chevron-left" className="mr-2 size-4" />
+                  See all posts
+                </Link>
+              </Button>
+            </div>
+            <div className="flex flex-row items-center justify-end gap-2">
+              <ShareButton post={post} />
+              <ScrollToTopButton />
+            </div>
           </div>
         </div>
-        <Image
-          src={post.cover.src}
-          width={post.cover.width}
-          height={post.cover.height}
-          placeholder="blur"
-          blurDataURL={post.cover.blurDataURL}
-          className="rounded-md border bg-muted transition-colors"
-          alt={`Cover image for ${post.title}`}
-        />
-        <article>
-          <MDXContent code={post.body} />
-        </article>
-        <hr />
-        <div className="flex flex-row items-center justify-between gap-4">
-          <div>
-            <Button variant="outline" asChild>
-              <Link href="/blog">
-                <Icon.Lucide name="chevron-left" className="mr-2 size-4" />
-                See all posts
-              </Link>
-            </Button>
-          </div>
-          <div className="flex flex-row items-center justify-end gap-2">
-            <ShareButton post={post} />
-            <ScrollToTopButton />
+        <div className="hidden text-sm lg:block">
+          <div
+            className={cn(
+              'sticky top-[var(--offset-top)] max-h-[calc(theme(maxHeight.dvh)-var(--offset-top))] overflow-y-auto',
+              '[--offset-top:calc(var(--header-height)+theme(spacing.10))]',
+            )}
+          >
+            <PostTableOfContent toc={post.toc} />
           </div>
         </div>
       </section>

--- a/components/toc.tsx
+++ b/components/toc.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { type JSX } from 'react';
+import Link from 'next/link';
+import { type TocEntry } from '@/types/velite';
+import { useObserveToc } from '@/hooks/use-observe-toc';
+import { cn } from '@/lib/utils';
+
+interface TocProps {
+  toc: TocEntry[];
+}
+
+export function PostTableOfContent({ toc }: TocProps): JSX.Element {
+  const activeTocId = useObserveToc(toc);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h2 className="mb-2 text-sm font-semibold">On this page</h2>
+      <nav className="flex flex-col gap-2">
+        <Tree tree={toc} activeTocId={activeTocId} />
+      </nav>
+    </div>
+  );
+}
+
+interface TreeProps {
+  tree: TocEntry[];
+  activeTocId: string;
+  level?: number;
+}
+
+function Tree({ tree, activeTocId, level = 1 }: TreeProps): JSX.Element {
+  return (
+    <ul className={cn('m-0 list-none', { 'pl-4': level === 2 })}>
+      {tree.map((entry) => (
+        <li key={entry.url} className="mt-0 pt-2">
+          <Link
+            href={entry.url}
+            className={cn(
+              'inline-block no-underline',
+              entry.url === `#${activeTocId}`
+                ? 'font-medium text-primary'
+                : 'text-sm text-muted-foreground',
+            )}
+          >
+            {entry.title}
+          </Link>
+          {entry.items ? (
+            <Tree
+              tree={entry.items}
+              activeTocId={activeTocId}
+              level={level + 1}
+            />
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/hooks/use-observe-toc.ts
+++ b/hooks/use-observe-toc.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { type TocEntry } from '@/types/velite';
+
+function flatItem(item: TocEntry): TocEntry[] {
+  if (!item.items) {
+    return [item];
+  }
+  return [{ ...item, items: [] }, ...item.items.flatMap(flatItem)];
+}
+
+function getTocIds(toc: TocEntry[]): string[] {
+  return toc
+    .flatMap((item) => flatItem(item))
+    .map(({ url }) => url.split('#').slice(1).join('#'));
+}
+
+export function useObserveToc(toc: TocEntry[]): string {
+  const [activeTocId, setActiveTocId] = useState<string>('');
+
+  useEffect(() => {
+    const tocIds = getTocIds(toc);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const activeEntry = entries.find((entry) => entry.isIntersecting);
+        if (activeEntry) {
+          setActiveTocId(activeEntry.target.id);
+        }
+      },
+      {
+        rootMargin: '0px 0px -80% 0px',
+      },
+    );
+
+    tocIds.forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      tocIds.forEach((id) => {
+        const element = document.getElementById(id);
+        if (element) {
+          observer.unobserve(element);
+        }
+      });
+      observer.disconnect();
+    };
+  }, [toc]);
+
+  return activeTocId;
+}

--- a/types/velite.ts
+++ b/types/velite.ts
@@ -1,0 +1,5 @@
+export interface TocEntry {
+  title: string;
+  url: string;
+  items?: TocEntry[];
+}


### PR DESCRIPTION
Closes #67 

* **feat(blog): add table of content to blog posts**
This commit introduces a table of contents feature for blog posts. It includes the addition of a table of contents to the post page, implementation of a new hook to observe the table of contents, creation of a new component to render the table of contents, and definition of a new type for the Velite table of contents. These enhancements improve navigation and readability for blog readers.
